### PR TITLE
Fix: Migration for Previously OCRed Items

### DIFF
--- a/db/migrate/20250603174302_backfill_ocred_on_items.rb
+++ b/db/migrate/20250603174302_backfill_ocred_on_items.rb
@@ -1,0 +1,9 @@
+class BackfillOcredOnItems < ActiveRecord::Migration[7.1]
+  def up
+    Item.find_each do |item|
+      if item.ocred_binaries.exists?
+        item.update_column(:ocred, true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_21_163958) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_03_174302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Related to Issue [154](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=110314775&issue=medusa-project%7Cdigital-library-issues%7C154) & [Pull Req. 41](https://github.com/medusa-project/kumquat/pull/41)

- The latest change on Demo sets `ocred :true` only on **newly** OCRed items, however  items that have already been OCRed are still incorrectly showing `ocred :false`

<img width="834" alt="Screenshot 2025-06-03 at 10 50 25 AM" src="https://github.com/user-attachments/assets/3139d494-2641-49cd-ad38-ae6615bb1464" />
<img width="963" alt="Screenshot 2025-06-03 at 10 50 35 AM" src="https://github.com/user-attachments/assets/27466517-d305-4175-87af-e92a6eaed09d" />

### Changes:
This PR introduces a one time migration that retroactively applies `ocred :true` for any items that have already been OCRed

