### PR TITLE
Bug - Unpublished Items showing in search results

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -561,12 +561,6 @@ module Admin
                                                          user: current_user)
         end
         
-        # Explicitly reindex the item outside the transaction to ensure 
-        # the search index gets the committed database changes
-        Rails.logger.info "About to reindex item #{@item.repository_id} (published: #{@item.published})"
-        @item.reindex
-        Rails.logger.info "Reindexed item #{@item.repository_id} (#{@item.title}) after update"
-        
       end
     rescue => e
       handle_error(e)
@@ -687,22 +681,12 @@ module Admin
         items    = relation.to_a.select(&:present?)
         ids      = items.map(&:repository_id)
       end
-      Item.where('repository_id IN (?)', ids)
-          .update_all(published: publish)
+      Item.where('repository_id IN (?)', ids).find_each do |item|
+        item.update!(published: publish)
+      end
     rescue => e
       handle_error(e)
     else
-      # Reindex the affected items to update the search index
-      # Do this after successful update to avoid reindexing if update fails
-      begin
-        items_to_reindex = Item.where('repository_id IN (?)', ids)
-        items_to_reindex.find_each(&:reindex)
-        Rails.logger.info "Reindexed #{items_to_reindex.count} items after #{publish ? 'publishing' : 'unpublishing'}"
-      rescue => reindex_error
-        Rails.logger.error "Failed to reindex items: #{reindex_error.message}"
-        # Don't fail the whole operation if reindexing fails, but log it
-      end
-      
       flash['success'] = "#{publish ? 'P' : 'Unp'}ublished #{ids.length} items."
     ensure
       redirect_back fallback_location: admin_collection_items_path(@collection)

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -560,6 +560,13 @@ module Admin
           PropagatePropertiesToChildrenJob.perform_later(item: @item,
                                                          user: current_user)
         end
+        
+        # Explicitly reindex the item outside the transaction to ensure 
+        # the search index gets the committed database changes
+        Rails.logger.info "About to reindex item #{@item.repository_id} (published: #{@item.published})"
+        @item.reindex
+        Rails.logger.info "Reindexed item #{@item.repository_id} (#{@item.title}) after update"
+        
       end
     rescue => e
       handle_error(e)
@@ -685,6 +692,17 @@ module Admin
     rescue => e
       handle_error(e)
     else
+      # Reindex the affected items to update the search index
+      # Do this after successful update to avoid reindexing if update fails
+      begin
+        items_to_reindex = Item.where('repository_id IN (?)', ids)
+        items_to_reindex.find_each(&:reindex)
+        Rails.logger.info "Reindexed #{items_to_reindex.count} items after #{publish ? 'publishing' : 'unpublishing'}"
+      rescue => reindex_error
+        Rails.logger.error "Failed to reindex items: #{reindex_error.message}"
+        # Don't fail the whole operation if reindexing fails, but log it
+      end
+      
       flash['success'] = "#{publish ? 'P' : 'Unp'}ublished #{ids.length} items."
     ensure
       redirect_back fallback_location: admin_collection_items_path(@collection)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -277,6 +277,7 @@ class ItemsController < WebsiteController
         include_children_in_results(true).
         order(Item::IndexFields::STRUCTURAL_SORT).
         start(params[:download_start]).
+        include_unpublished(current_user&.medusa_admin? || false).
         limit(0)
     if params[:field]
       download_relation.query(params[:field], params[:q], true)
@@ -693,7 +694,8 @@ class ItemsController < WebsiteController
         collection(@collection).
         facet_filters(session[:fq]).
         order(sort).
-        start(session[:start])
+        start(session[:start]).
+        include_unpublished(current_user&.medusa_admin? || false)
 
     if collection_ids.present?
       relation.collections(collection_ids)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -350,6 +350,7 @@ class Item < ApplicationRecord
               :prune_identical_elements, :set_effective_host_groups,
               :set_normalized_coords, :set_normalized_date, :set_published_at
   
+  before_update :capture_published_change
   after_commit :reindex_if_published_changed
 
   ##
@@ -1736,13 +1737,24 @@ class Item < ApplicationRecord
   end
 
   ##
+  # Captures the published status change before update for logging.
+  #
+  def capture_published_change
+    if will_save_change_to_published?
+      @published_change = changes_to_save['published']
+    end
+  end
+
+  ##
   # Reindexes the item if its published status has changed.
   # This ensures the search index stays consistent when items are published/unpublished.
   #
   def reindex_if_published_changed
-    if saved_change_to_published?
-      Rails.logger.info "Reindexing item #{repository_id} due to published status change (#{published_was} -> #{published})"
+    if @published_change
+      old_value, new_value = @published_change
+      Rails.logger.info "Reindexing item #{repository_id} due to published status change (#{old_value} -> #{new_value})"
       reindex
+      @published_change = nil  # Clear the captured change
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1836,15 +1836,4 @@ class Item < ApplicationRecord
 
   private
 
-  ##
-  # Reindexes the item if its published status changed.
-  # This ensures the search index stays consistent when items are published/unpublished.
-  #
-  def reindex_if_published_changed
-    if saved_change_to_published?
-      Rails.logger.info "Reindexing item #{repository_id} due to published status change (#{published_was} -> #{published})"
-      reindex
-    end
-  end
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1834,4 +1834,17 @@ class Item < ApplicationRecord
     StringUtils.pad_numbers(str, '0', padding)
   end
 
+  private
+
+  ##
+  # Reindexes the item if its published status changed.
+  # This ensures the search index stays consistent when items are published/unpublished.
+  #
+  def reindex_if_published_changed
+    if saved_change_to_published?
+      Rails.logger.info "Reindexing item #{repository_id} due to published status change (#{published_was} -> #{published})"
+      reindex
+    end
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -349,6 +349,8 @@ class Item < ApplicationRecord
   before_save :process_allowed_netids, :notify_netids,
               :prune_identical_elements, :set_effective_host_groups,
               :set_normalized_coords, :set_normalized_date, :set_published_at
+  
+  after_commit :reindex_if_published_changed
 
   ##
   # @return [Integer]
@@ -1730,6 +1732,17 @@ class Item < ApplicationRecord
           self.elements.reject{ |e| e.name == 'title' }.any?
         self.published_at = Time.now
       end
+    end
+  end
+
+  ##
+  # Reindexes the item if its published status has changed.
+  # This ensures the search index stays consistent when items are published/unpublished.
+  #
+  def reindex_if_published_changed
+    if saved_change_to_published?
+      Rails.logger.info "Reindexing item #{repository_id} due to published status change (#{published_was} -> #{published})"
+      reindex
     end
   end
 

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -274,7 +274,7 @@ class ItemRelation < AbstractRelation
             unless @include_unpublished
               j.child! do
                 j.term do
-                  j.set! Item::IndexFields::PUBLISHED, true
+                  j.set! Item::IndexFields::PUBLICLY_ACCESSIBLE, true
                 end
               end
             end

--- a/app/search/simple_item_search.rb
+++ b/app/search/simple_item_search.rb
@@ -24,11 +24,9 @@ class SimpleItemSearch < ItemRelation
   private
 
   def apply_filters
-    if @dls_only
-      # Filter to items from published collections
-      filter(Item::IndexFields::PUBLISHED, true)
-    end
-
+    # Note: include_unpublished(false) already filters to published items,
+    # so we don't need the redundant filter() call here
+    
     include_unpublished(false)
     include_restricted(false)
     include_publicly_inaccessible(false)


### PR DESCRIPTION
Addresses issue/bug [203](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=161851487&issue=medusa-project%7Cdigital-library-issues%7C203), where unpublished items are still being shown in search results. When a non-admin user clicks on those items they are shown a 403 Forbidden Error. This is confusing for users. Solution is to make sure unpublished items should never show up in search results at all for non-admin users. 

Summary of Changes:
1. Updated Items Controller so only admin users can see unpublished items
2. ItemRelation builder uses parental hierarchy to published/unpublished items
3. Trigger an automatic reindexing of updated items inside Item model 
4. Search filtering was only checking individual item published status instead of the full hierarchy via publicly_accessible status

Tests:
- Tested locally by un-publishing an item as an Admin user and verifying the item did not appear in the search results as a non-Admin user
- Tested in Rails console with the following:

```ruby
item = Item.find_by_repository_id(":id")

# Toggle published status to test the callback
item.update!(published: false)

# Wait and check if it appears in search 
sleep(2)
search = SimpleItemSearch.new(query: "forest map of illinois")
results = search.results
found = results.any? { |r| r.repository_id == item.repository_id }
# item not found in search

# Republish item
item.update!(published: true)

# Wait and check search again 
sleep(2)
search = SimpleItemSearch.new(query: "forest map of illinois")
results = search.results
found = results.any? { |r| r.repository_id == item.repository_id }
# item found in search
```
