### PR TITLE
Repository Landing Page - Public Collections Count

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -11,11 +11,13 @@ class RepositoriesController < WebsiteController
     
     # Get unique repositories from these collections
     repositories_hash = {}
+    counts_hash = {}
     collections.each do |collection|
       begin
         repository = collection.medusa_repository
         if repository
-          repositories_hash[repository.id] = repository
+          repositories_hash[collection.medusa_repository_id] = repository
+          counts_hash[collection.medusa_repository_id] = (counts_hash[collection.medusa_repository_id] || 0) + 1
         end
       rescue => e
         Rails.logger.warn("Could not fetch repository for collection #{collection.repository_id}: #{e.message}")
@@ -24,6 +26,7 @@ class RepositoriesController < WebsiteController
     
     # Convert to array and sort by title
     @repositories = repositories_hash.values.sort_by(&:title)
+    @public_collection_counts = counts_hash
   end
 
   def show 

--- a/app/views/repositories/index.html.haml
+++ b/app/views/repositories/index.html.haml
@@ -6,7 +6,8 @@
   %ul.nav-item
     = link_to repository.title, repository_path(repository.title.parameterize)
     .result-type-badge.mb-2
+      - public_count = @public_collection_counts[repository.id] || 0
       %span.badge.badge-primary
-        #{repository.collections.count} #{'Collection'.pluralize(repository.collections.count)}
+        #{public_count} #{'Collection'.pluralize(public_count)}
   
 


### PR DESCRIPTION
Part of Parent Issue ([6](https://github.com/medusa-project/digital-library-issues/issues/6)), specifically addressing the Repositories Landing page. 

Summary of Changes:
- Each Repository is labeled with how many collections are a part of it. 
- Update count to only display collections that are both `public in Medusa` and `published in DLS`
- If a repo does not have any collections that satisfy those requirements, the repo will not be displayed.

<img width="629" height="631" alt="Screenshot 2026-04-16 at 2 20 58 PM" src="https://github.com/user-attachments/assets/678d6d39-b559-4385-8f8b-813be7816042" />


