### PR TITLE
Bugfix: Firefox and Safari browsers image fullscreen

### DIFF
--- a/public/universalviewer/cjs/Init.js
+++ b/public/universalviewer/cjs/Init.js
@@ -86,45 +86,37 @@ var init = function (el, data) {
     function fullScreenChange(e) {
         if ((e.type === "webkitfullscreenchange" && !document.webkitIsFullScreen) ||
             (e.type === "fullscreenchange" && !document.fullscreenElement) ||
-            (e.type === "mozfullscreenchange" && !document.mozFullScreen) ||
             (e.type === "MSFullscreenChange" && document.msFullscreenElement === null)) {
             uv.exitFullScreen();
         }
     }
     document.addEventListener("fullscreenchange", fullScreenChange, false);
     document.addEventListener("webkitfullscreenchange", fullScreenChange, false);
-    document.addEventListener("mozfullscreenchange", fullScreenChange, false);
     document.addEventListener("MSFullscreenChange", fullScreenChange, false);
     return uv;
 };
 exports.init = init;
 function getRequestFullScreen(elem) {
+    if (elem.requestFullscreen) {
+        return elem.requestFullscreen;
+    }
     if (elem.webkitRequestFullscreen) {
         return elem.webkitRequestFullscreen;
-    }
-    if (elem.mozRequestFullScreen) {
-        return elem.mozRequestFullScreen;
     }
     if (elem.msRequestFullscreen) {
         return elem.msRequestFullscreen;
     }
-    if (elem.requestFullscreen) {
-        return elem.requestFullscreen;
-    }
     return false;
 }
 function getExitFullScreen() {
+    if (document.exitFullscreen) {
+        return document.exitFullscreen;
+    }
     if (document.webkitExitFullscreen) {
         return document.webkitExitFullscreen;
     }
     if (document.msExitFullscreen) {
         return document.msExitFullscreen;
-    }
-    if (document.mozCancelFullScreen) {
-        return document.mozCancelFullScreen;
-    }
-    if (document.exitFullscreen) {
-        return document.exitFullscreen;
     }
     return false;
 }


### PR DESCRIPTION
Addresses [bug 204](https://github.com/medusa-project/digital-library-issues/issues/204#issuecomment-4423514464)

- When viewing an image inside the viewer in `firefox or safari browsers`, upon exiting the fullscreen view, the page displays a large black box, with the image below it. 
<img width="1301" height="832" alt="Screenshot 2026-05-11 at 2 05 51 PM" src="https://github.com/user-attachments/assets/6a80d96f-7c01-4b69-9778-c22d7de90f46" />

- The fullscreen function works normally in chrome
- Looking at developer tools inside firefox, a `mozRequestFullScreen() is deprecated. UV.js:2:168288` error appears in the console
- This has been a known error with Universal Viewer and requires` removing any mozilla-specific language from the UV initialization`, falling back on default fullscreen configuration for IE/Edge, Safari and all other browsers

```javascript
var init = function (el, data) {
     function fullScreenChange(e) {
         if ((e.type === "webkitfullscreenchange" && !document.webkitIsFullScreen) ||
             (e.type === "fullscreenchange" && !document.fullscreenElement) ||
             (e.type === "mozfullscreenchange" && !document.mozFullScreen) || // remove
             (e.type === "MSFullscreenChange" && document.msFullscreenElement === null)) {
             uv.exitFullScreen();
         }
     }
     document.addEventListener("fullscreenchange", fullScreenChange, false);
     document.addEventListener("webkitfullscreenchange", fullScreenChange, false);
     document.addEventListener("mozfullscreenchange", fullScreenChange, false); // remove
     document.addEventListener("MSFullscreenChange", fullScreenChange, false);
     return uv;
 };  
function getRequestFullScreen(elem) {
    if (elem.requestFullscreen) {
        return elem.requestFullscreen; // add standard fullscreen request as default
    }
     if (elem.webkitRequestFullscreen) {
         return elem.webkitRequestFullscreen;
     }
    if (elem.mozRequestFullScreen) {
        return elem.mozRequestFullScreen; // remove
    }
     if (elem.msRequestFullscreen) {
         return elem.msRequestFullscreen;
     }
    if (elem.requestFullscreen) {
        return elem.requestFullscreen;
    }
     return false;
 }
 function getExitFullScreen() {
    if (document.exitFullscreen) {
        return document.exitFullscreen; // default to standard fullscreen exit
    }
     if (document.webkitExitFullscreen) {
         return document.webkitExitFullscreen;
     }
     if (document.msExitFullscreen) {
         return document.msExitFullscreen;
     }
    if (document.mozCancelFullScreen) {
        return document.mozCancelFullScreen; // remove
    }
   if (document.exitFullscreen) {
      return document.exitFullscreen;
   }
     return false;
 }