### PR TITLE
Advanced Search Feature

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -100,6 +100,15 @@ const Application = {
         const clearBtn = document.getElementById('advanced-search-clear');
 
         let rowIndex = 1; 
+
+        addBtn.addEventListener('click', function() {
+            const clone = template.cloneNode(true);
+            clone.removeAttribute('id');
+            clone.style.display = '';
+            clone.innerHTML = clone.innerHTML.replaceAll('[N]', '[' + rowIndex + ']');
+            criteria.appendChild(clone);
+            rowIndex++;
+        });
     },
 
     /**

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -104,6 +104,7 @@ const Application = {
         addBtn.addEventListener('click', function() {
             const clone = template.cloneNode(true);
             clone.removeAttribute('id');
+            clone.classList.add('advanced-search-row');
             clone.style.display = '';
             clone.querySelectorAll('input, select').forEach(function(element) {
                 element.disabled = false;

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -127,6 +127,32 @@ const Application = {
           });
           rowIndex = 1;
         });
+
+        form.addEventListener('submit', function(e) {
+          e.preventDefault();
+          const rows = criteria.querySelectorAll('.advanced-search-row');
+          const parts = [];
+          rows.forEach(function(row, index) {
+            const field = row.querySelector('select[name*="field"]').value;
+            const query = row.querySelector('input[type="text"]').value;
+            const match = row.querySelector('select[name*="match"]').value;
+            const operator = index === 0 ? null : row.querySelector('select[name*="operator"]').value;
+            if (!query) return;
+            let term;
+            if (match === 'phrase'){
+              term = field === 'search_all' ? '"' + query + '"' : field + ':"' + query + '"';
+            } else if (match === 'any') {
+              term = field === 'search_all' ? query.split(' ').join(' | ') : field + ':(' + query.split(' ').join(' | ') + ')';
+            } else {
+              term = field === 'search_all' ? query : field + ':(' + query + ')';
+            }
+            
+            parts.push(index === 0 ? term : operator + ' ' + term);
+          });
+
+          form.querySelector('input[name="q"]').value = parts.join(' ');
+          form.submit();
+        });
     },
 
     /**

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -89,6 +89,19 @@ const Application = {
         });
     },
 
+    initAdvancedSearch: function() {
+        const form = document.getElementById('advanced-search-form');
+        if (!form) {
+            return;
+        }
+        const criteria = document.getElementById('advanced-search-criteria');
+        const template = document.getElementById('advanced-search-row-template');
+        const addBtn = document.getElementById('add-advanced-search-row');
+        const clearBtn = document.getElementById('advanced-search-clear');
+
+        let rowIndex = 1; 
+    },
+
     /**
      * @returns {Boolean}
      */

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -138,7 +138,7 @@ const Application = {
           const parts = [];
           rows.forEach(function(row, index) {
             const field = row.querySelector('select[name*="field"]').value;
-            const query = row.querySelector('input[type="text"]').value;
+            const query = row.querySelector('input[type="text"]').value.trim();
             const match = row.querySelector('select[name*="match"]').value;
             const operator = index === 0 ? null : row.querySelector('select[name*="operator"]').value;
             if (!query) return;

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -143,10 +143,13 @@ const Application = {
             const operator = index === 0 ? null : row.querySelector('select[name*="operator"]').value;
             if (!query) return;
             let term;
-            if (match === 'phrase'){
+            if (match === 'phrase') {
               term = field === 'search_all' ? '"' + query + '"' : field + ':"' + query + '"';
             } else if (match === 'any') {
               term = field === 'search_all' ? query.split(' ').join(' | ') : field + ':(' + query.split(' ').join(' | ') + ')';
+            } else if (match === 'fuzzy') {
+              const fuzzyTerms = query.split(' ').map(function(w) { return w + '~'; }).join(' ');
+              term = field === 'search_all' ? fuzzyTerms : field + ':(' + fuzzyTerms + ')';
             } else {
               term = field === 'search_all' ? query : field + ':(' + query + ')';
             }

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -135,29 +135,11 @@ const Application = {
         form.addEventListener('submit', function(e) {
           e.preventDefault();
           const rows = criteria.querySelectorAll('.advanced-search-row');
-          const parts = [];
-          rows.forEach(function(row, index) {
-            const field = row.querySelector('select[name*="field"]').value;
-            const query = row.querySelector('input[type="text"]').value.trim();
-            const match = row.querySelector('select[name*="match"]').value;
-            const operator = index === 0 ? null : row.querySelector('select[name*="operator"]').value;
-            if (!query) return;
-            let term;
-            if (match === 'phrase') {
-              term = field === 'search_all' ? '"' + query + '"' : field + ':"' + query + '"';
-            } else if (match === 'any') {
-              term = field === 'search_all' ? query.split(' ').join(' | ') : field + ':(' + query.split(' ').join(' | ') + ')';
-            } else if (match === 'fuzzy') {
-              const fuzzyTerms = query.split(' ').map(function(w) { return w + '~'; }).join(' ');
-              term = field === 'search_all' ? fuzzyTerms : field + ':(' + fuzzyTerms + ')';
-            } else {
-              term = field === 'search_all' ? query : field + ':(' + query + ')';
-            }
-
-            parts.push(index === 0 ? term : operator + ' ' + term);
+          let hasQuery = false;
+          rows.forEach(function(row) {
+            if (row.querySelector('input[type="text"]').value.trim()) hasQuery = true;
           });
-
-          form.querySelector('input[name="q"]').value = parts.join(' ');
+          if (!hasQuery) return;
           form.submit();
         });
     },

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -105,6 +105,9 @@ const Application = {
             const clone = template.cloneNode(true);
             clone.removeAttribute('id');
             clone.style.display = '';
+            clone.querySelectorAll('input, select').forEach(function(element) {
+                element.disabled = false;
+            });
             clone.innerHTML = clone.innerHTML.replaceAll('[N]', '[' + rowIndex + ']');
             criteria.appendChild(clone);
             rowIndex++;
@@ -146,7 +149,7 @@ const Application = {
             } else {
               term = field === 'search_all' ? query : field + ':(' + query + ')';
             }
-            
+
             parts.push(index === 0 ? term : operator + ' ' + term);
           });
 

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -109,6 +109,12 @@ const Application = {
             criteria.appendChild(clone);
             rowIndex++;
         });
+
+        criteria.addEventListener('click', function(e) {
+          if (e.target.closest('.remove-advanced-row-btn')) {
+            e.target.closest('.advanced-search-row').remove();
+          }
+        });
     },
 
     /**

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -115,6 +115,18 @@ const Application = {
             e.target.closest('.advanced-search-row').remove();
           }
         });
+
+        clearBtn.addEventListener('click', function() {
+          document.querySelectorAll('#advanced-search-criteria .advanced-search-row').forEach(function(row) {
+            if (row.dataset.row === '0') {
+              row.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+              row.querySelector('input[type="text"]').value = '';
+            } else {
+              row.remove();
+            }
+          });
+          rowIndex = 1;
+        });
     },
 
     /**

--- a/app/controllers/search_landing_controller.rb
+++ b/app/controllers/search_landing_controller.rb
@@ -1,5 +1,5 @@
 class SearchLandingController < WebsiteController 
-  PERMITTED_PARAMS = [{ fq: [] }, :q, :sort, :start, :utf8, :commit, :tab, :'dl-current-path', :_, :format]
+  PERMITTED_PARAMS = [{ fq: [] }, :q, :sort, :start, :utf8, :commit, :tab, :'dl-current-path', :_, :format, {criteria: {}}]
 
   before_action :set_sanitized_params
   
@@ -15,6 +15,7 @@ class SearchLandingController < WebsiteController
     # Use unified search for both collections and items
     search = SpecialCollectionSearch.new(
       query: @permitted_params[:q],
+      criteria: @permitted_params[:criteria],
       start: @start,
       limit: @limit,
       facet_filters: @permitted_params[:fq]

--- a/app/search/abstract_relation.rb
+++ b/app/search/abstract_relation.rb
@@ -22,6 +22,7 @@ class AbstractRelation
     @limit        = OpensearchClient::MAX_RESULT_WINDOW
     @orders       = [] # Array<Hash<Symbol,String>> with :field and :direction keys
     @query        = nil # Hash<Symbol,String> Hash with :field and :query keys
+    @query_clauses = nil # Array of clause hashes for multi-field boolean search
     @start        = 0
 
     @loaded = false

--- a/app/search/abstract_relation.rb
+++ b/app/search/abstract_relation.rb
@@ -161,6 +161,18 @@ class AbstractRelation
   end
 
   ##
+  # Adds a multi-clause boolean query for field-specific advanced search.
+  #
+  # @param clauses [Array<Hash>] Each hash has :field, :query, :match, :operator keys
+  # @return [self]
+  #
+  def query_clauses(clauses)
+    @query_clauses = clauses.select { |c| c[:query].present? }
+    @loaded = false
+    self
+  end
+
+  ##
   # Adds a query to search all fields.
   #
   # @param query [String]

--- a/app/search/abstract_relation.rb
+++ b/app/search/abstract_relation.rb
@@ -278,6 +278,27 @@ class AbstractRelation
     end
   end
 
+  ##
+  # Builds an OpenSearch query clause hash for a single criteria row.
+  #
+  # @param field [String] OpenSearch field name (e.g. 'metadata_title', 'search_all')
+  # @param query_text [String]
+  # @param match_type [String] 'all', 'any', 'phrase', or 'fuzzy'
+  # @return [Hash]
+  #
+  def build_clause_hash(field, query_text, match_type)
+    case match_type.to_s
+    when 'phrase'
+      { 'match_phrase' => { field => query_text } }
+    when 'fuzzy'
+      { 'match' => { field => { 'query' => query_text, 'fuzziness' => 'AUTO', 'operator' => 'AND', 'lenient' => true } } }
+    when 'any'
+      { 'simple_query_string' => { 'query' => query_text, 'fields' => [field], 'default_operator' => 'OR', 'lenient' => true } }
+    else # 'all'
+      { 'simple_query_string' => { 'query' => query_text, 'fields' => [field], 'default_operator' => 'AND', 'lenient' => true } }
+    end
+  end
+
   def get_response
     @request_json = build_query
     result = @client.query(@request_json)

--- a/app/search/collection_relation.rb
+++ b/app/search/collection_relation.rb
@@ -121,12 +121,32 @@ class CollectionRelation < AbstractRelation
   # @return [String] JSON string.
   #
   def build_query
+    # Pre-compute criteria clause arrays for multi-field boolean search
+    criteria_must, criteria_should, criteria_must_not = [], [], []
+    if @query_clauses.present?
+      @query_clauses.each_with_index do |clause, idx|
+        ch = build_clause_hash(clause[:field], clause[:query], clause[:match])
+        op = (idx == 0) ? 'AND' : clause[:operator].to_s.upcase
+        case op
+        when 'OR'  then criteria_should << ch
+        when 'NOT' then criteria_must_not << ch
+        else            criteria_must << ch
+        end
+      end
+    end
+
     Jbuilder.encode do |j|
       j.track_total_hits true
       j.query do
         j.bool do
           # Query
-          if @query.present?
+          if @query_clauses.present?
+            j.must criteria_must unless criteria_must.empty?
+            unless criteria_should.empty?
+              j.should criteria_should
+              j.minimum_should_match 1 unless criteria_must.any?
+            end
+          elsif @query.present?
             j.must do
               # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
               j.simple_query_string do
@@ -207,6 +227,9 @@ class CollectionRelation < AbstractRelation
                 j.exists do
                   j.field Collection::IndexFields::PARENT_COLLECTIONS
                 end
+              end
+              criteria_must_not.each do |clause_hash|
+                j.child! { j.merge!(clause_hash) }
               end
             end
           end

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -164,12 +164,33 @@ class ItemRelation < AbstractRelation
   #
   def build_query
     collections_array = @collections ? Array(@collections).flatten.compact : nil
+
+    # Pre-compute criteria clause arrays for multi-field boolean search
+    criteria_must, criteria_should, criteria_must_not = [], [], []
+    if @query_clauses.present?
+      @query_clauses.each_with_index do |clause, idx|
+        ch = build_clause_hash(clause[:field], clause[:query], clause[:match])
+        op = (idx == 0) ? 'AND' : clause[:operator].to_s.upcase
+        case op
+        when 'OR'  then criteria_should << ch
+        when 'NOT' then criteria_must_not << ch
+        else            criteria_must << ch
+        end
+      end
+    end
+
     Jbuilder.encode do |j|
       j.track_total_hits true
       j.query do
         j.bool do
           # Query
-          if @query.present?
+          if @query_clauses.present?
+            j.must criteria_must unless criteria_must.empty?
+            unless criteria_should.empty?
+              j.should criteria_should
+              j.minimum_should_match 1 unless criteria_must.any?
+            end
+          elsif @query.present?
             j.must do
               if !@exact_match
                 # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
@@ -309,7 +330,7 @@ class ItemRelation < AbstractRelation
             j.minimum_should_match 1
           end
 
-          if @exclude_variants.any? || (!@include_children_in_results && !@search_children)
+          if @exclude_variants.any? || (!@include_children_in_results && !@search_children) || criteria_must_not.any?
             j.must_not do
               if @exclude_variants.any?
                 j.child! do
@@ -325,6 +346,10 @@ class ItemRelation < AbstractRelation
                     j.field Item::IndexFields::PARENT_ITEM
                   end
                 end
+              end
+
+              criteria_must_not.each do |clause_hash|
+                j.child! { j.merge!(clause_hash) }
               end
             end
           end

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -4,13 +4,15 @@ class SpecialCollectionSearch
   
   ##
   # @param query [String] Search query string
+  # @param criteria [Hash] Advanced search criteria keyed by row index
   # @param start [Integer] Starting position for pagination
   # @param limit [Integer] Number of results per page
   # @param facet_filters [Array] Facet filters to apply
   # @param repository_id [Integer] Optional repository ID to scope search to specific repository
   #
-  def initialize(query: nil, start: 0, limit: 40, facet_filters: [], repository_id: nil)
+  def initialize(query: nil, criteria: nil, start: 0, limit: 40, facet_filters: [], repository_id: nil)
     @search_query = query
+    @criteria = criteria
     @start = start
     @limit = limit
     @facet_filters = facet_filters || []

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -109,6 +109,32 @@ class SpecialCollectionSearch
 
   private
   
+  ##
+  # Converts the @criteria params hash (keyed by row index) into an array of
+  # clause hashes suitable for AbstractRelation#query_clauses.
+  #
+  def build_criteria_clauses
+    return [] unless @criteria.present?
+
+    allowed_fields = %w[search_all metadata_title metadata_creator metadata_contributor
+                        metadata_subject metadata_description metadata_date metadata_language
+                        metadata_type metadata_identifier metadata_publisher metadata_format
+                        metadata_rights metadata_spatialCoverage]
+    allowed_matches = %w[all any phrase fuzzy]
+    allowed_operators = %w[AND OR NOT]
+
+    @criteria.to_unsafe_h.sort_by { |k, _| k.to_i }.filter_map do |_idx, row|
+      query_text = row['query'].to_s.strip
+      next if query_text.blank?
+
+      field    = allowed_fields.include?(row['field']) ? row['field'] : 'search_all'
+      match    = allowed_matches.include?(row['match']) ? row['match'] : 'all'
+      operator = allowed_operators.include?(row['operator']&.upcase) ? row['operator'].upcase : 'AND'
+
+      { field: field, query: query_text, match: match, operator: operator }
+    end
+  end
+
   def combine_and_sort_results
     # Simple approach: show collections first, then items
     # You could implement more sophisticated relevance scoring here

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -28,8 +28,11 @@ class SpecialCollectionSearch
   # Executes the search and populates results
   #
   def execute!
+    clauses = build_criteria_clauses
+
     # Search collections
     collection_search = SimpleCollectionSearch.new(query: @search_query)
+    collection_search.query_clauses(clauses) if clauses.any?
     collection_search.facet_filters(@facet_filters)
     collection_search.start(@start).limit(@limit)
     collection_search.aggregations(true)
@@ -59,6 +62,7 @@ class SpecialCollectionSearch
     
     # Search items  
     item_search = SimpleItemSearch.new(query: @search_query)
+    item_search.query_clauses(clauses) if clauses.any?
     item_search.facet_filters(@facet_filters)
     item_search.start(@start).limit(@limit)
     item_search.aggregations(true)

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -100,3 +100,28 @@
               %h6.fw-bold.mb-3 Enter Search Term:
 
               #advanced-search-criteria 
+
+                .advanced-search-row{data: {row:'0'}}
+                  .row.g-2.mb-2
+                    .col-12 
+                      = select_tag('criteria[0][field]', options_for_select([['Keyword', 'search_all'], 
+                                                                            ['Title', 'metadata_title'],
+                                                                            ['Creator', 'metadata_creator'],
+                                                                            ['Contributor', 'metadata_contributor'],
+                                                                            ['Subject', 'metadata_subject'], 
+                                                                            ['Description', 'metadata_description'],
+                                                                            ['Author', 'metadata_author'],
+                                                                            ['Date', 'metadata_date'],
+                                                                            ['Language', 'metadata_language'],
+                                                                            ['Type', 'metadata_type'],
+                                                                            ['Identifier', 'metadata_identifier'],
+                                                                            ['Publisher', 'metadata_publisher'],
+                                                                            ['Format', 'metadata_format'],
+                                                                            ['Rights', 'metadata_rights'],
+                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
+                  
+                  .row.g-2 
+                    .col-sm-8 
+                    // text input for search term(s)
+                    .col-sm-4 
+                    // match type options 

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -165,3 +165,26 @@
           .d-flex.justify-content-end.gap-2
             %button.btn.btn-outline-secondary{type: 'button', id: 'advanced-search-clear'} Clear
             = submit_tag('Search', class: 'btn btn-primary', id: 'advanced-search-submit')
+
+    .row.justify-content-md-center.mt-4
+      .col-md-auto
+        = paginate(@count, @limit, @current_page, SearchLandingController::PERMITTED_PARAMS)
+
+    = form_tag(@permitted_params.reject{ |k, v| k == 'start' }, method: :get, class: 'dl-filter') do
+      = hidden_field_tag 'dl-current-path', request.path
+      - @permitted_params.reject{ |k, v| k == 'start' }.each do |k, v|
+        - if v.is_a?(Array)
+          - v.each do |item|
+            = hidden_field_tag("#{k}[]", item)
+        - else
+          = hidden_field_tag(k, v)
+      = hidden_field_tag(:tab, 'advanced-search')
+    
+    .row
+      .col-sm-3.col-lg-2
+        .facets
+          = facets_as_cards(@facets, SearchLandingController::PERMITTED_PARAMS)
+
+      .col-sm-9.col-lg-10
+        #search-results-container
+          = render 'search_results'

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -127,7 +127,8 @@
                     .col-sm-4 
                       = select_tag('criteria[0][match]', options_for_select([['All of the words', 'all'], 
                                                                             ['Any of the words', 'any'], 
-                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
+                                                                            ['Exact phrase', 'phrase'],
+                                                                            ['Fuzzy match', 'fuzzy']], 'all'), class: 'form-select')
 
                 #advanced-search-row-template{style: 'display:none'}
                   .row.g-2.mb-2

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -127,3 +127,31 @@
                       = select_tag('criteria[0][match]', options_for_select([['All of the words', 'all'], 
                                                                             ['Any of the words', 'any'], 
                                                                             ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
+
+                  #advanced-search-row-template{style: 'display:none'}
+                    .row.g-2.mb-2
+                      .col-sm-2 
+                        = select_tag('criteria[N][operator]', options_for_select([['and', 'AND'], ['or', 'OR'], ['not', 'NOT']], 'AND'), 
+                                                                                  class: 'form-select')
+                      .col-sm-10 
+                        = select_tag('criteria[N][field]', options_for_select([['Keyword', 'search_all'], 
+                                                                              ['Title', 'metadata_title'],
+                                                                              ['Creator', 'metadata_creator'],
+                                                                              ['Contributor', 'metadata_contributor'],
+                                                                              ['Subject', 'metadata_subject'], 
+                                                                              ['Description', 'metadata_description'],
+                                                                              ['Author', 'metadata_author'],
+                                                                              ['Date', 'metadata_date'],
+                                                                              ['Language', 'metadata_language'],
+                                                                              ['Type', 'metadata_type'],
+                                                                              ['Identifier', 'metadata_identifier'],
+                                                                              ['Publisher', 'metadata_publisher'],
+                                                                              ['Format', 'metadata_format'],
+                                                                              ['Rights', 'metadata_rights'],
+                                                                              ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
+                    .row.g-2
+                      .col-sm-7 
+                        = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term')
+                      .col-sm-3
+                      
+                      

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -122,6 +122,8 @@
                   
                   .row.g-2 
                     .col-sm-8 
-                    // text input for search term(s)
+                      = text_field_tag('criteria[0][query]', nil, class: 'form-control', placeholder: 'Enter search term')
                     .col-sm-4 
-                    // match type options 
+                      = select_tag('criteria[0][match]', options_for_select([['All of the words', 'all'], 
+                                                                            ['Any of the words', 'any'], 
+                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select')

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -132,7 +132,7 @@
                   .row.g-2.mb-2
                     .col-sm-2 
                       = select_tag('criteria[N][operator]', options_for_select([['and', 'AND'], ['or', 'OR'], ['not', 'NOT']], 'AND'), 
-                                                                                class: 'form-select')
+                                                                                class: 'form-select', disabled: true)
                     .col-sm-10 
                       = select_tag('criteria[N][field]', options_for_select([['Keyword', 'search_all'], 
                                                                             ['Title', 'metadata_title'],
@@ -147,14 +147,14 @@
                                                                             ['Publisher', 'metadata_publisher'],
                                                                             ['Format', 'metadata_format'],
                                                                             ['Rights', 'metadata_rights'],
-                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
+                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select', disabled: true)
                   .row.g-2
                     .col-sm-7 
-                      = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term')
+                      = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term', disabled: true)
                     .col-sm-3
                       = select_tag('criteria[N][match]', options_for_select([['All of the words', 'all'], 
                                                                             ['Any of the words', 'any'], 
-                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
+                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select', disabled: true)
                     .col-sm-2
                       %button.btn.btn-outline-danger.btn-sm.remove-advanced-row-btn{type: 'button'} &minus; Remove
           .d-flex.justify-content-end.mb-3 

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -110,7 +110,6 @@
                                                                             ['Contributor', 'metadata_contributor'],
                                                                             ['Subject', 'metadata_subject'], 
                                                                             ['Description', 'metadata_description'],
-                                                                            ['Author', 'metadata_author'],
                                                                             ['Date', 'metadata_date'],
                                                                             ['Language', 'metadata_language'],
                                                                             ['Type', 'metadata_type'],

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -6,6 +6,7 @@
 :javascript
   $(document).ready(function() {
     Application.initFacets();
+    Application.initAdvancedSearch();
     
     // Re-initialize facets when tab navigation links are clicked
     $('.nav-link').on('click', function() {

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -91,5 +91,12 @@
 
   #advanced-search.tab-pane.fade{class: [('show active' if active_tab == 'advanced-search')], role: "tabpanel"}
     .row.justify-content-md-center.mt-4
-      .col-md-8
-        %p.text-center.text-muted Advanced search content will go here
+      .col-md-10 
+        = form_tag(search_landing_path, method: :get, id: 'advanced-search-form') do
+          = hidden_field_tag(:tab, 'advanced-search')
+
+          .card.mb-3 
+            .card-body
+              %h6.fw-bold.mb-3 Enter Search Term:
+
+              #advanced-search-criteria 

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -94,6 +94,7 @@
       .col-md-10 
         = form_tag(search_landing_path, method: :get, id: 'advanced-search-form') do
           = hidden_field_tag(:tab, 'advanced-search')
+          = hidden_field_tag(:q, '')
 
           .card.mb-3 
             .card-body

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -179,12 +179,12 @@
         - else
           = hidden_field_tag(k, v)
       = hidden_field_tag(:tab, 'advanced-search')
-    
-    .row
-      .col-sm-3.col-lg-2
-        .facets
-          = facets_as_cards(@facets, SearchLandingController::PERMITTED_PARAMS)
+      
+      .row
+        .col-sm-3.col-lg-2
+          .facets
+            = facets_as_cards(@facets, SearchLandingController::PERMITTED_PARAMS)
 
-      .col-sm-9.col-lg-10
-        #search-results-container
-          = render 'search_results'
+        .col-sm-9.col-lg-10
+          #search-results-container
+            = render 'search_results'

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -127,30 +127,39 @@
                                                                             ['Any of the words', 'any'], 
                                                                             ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
 
-                  #advanced-search-row-template{style: 'display:none'}
-                    .row.g-2.mb-2
-                      .col-sm-2 
-                        = select_tag('criteria[N][operator]', options_for_select([['and', 'AND'], ['or', 'OR'], ['not', 'NOT']], 'AND'), 
-                                                                                  class: 'form-select')
-                      .col-sm-10 
-                        = select_tag('criteria[N][field]', options_for_select([['Keyword', 'search_all'], 
-                                                                              ['Title', 'metadata_title'],
-                                                                              ['Creator', 'metadata_creator'],
-                                                                              ['Contributor', 'metadata_contributor'],
-                                                                              ['Subject', 'metadata_subject'], 
-                                                                              ['Description', 'metadata_description'],
-                                                                              ['Author', 'metadata_author'],
-                                                                              ['Date', 'metadata_date'],
-                                                                              ['Language', 'metadata_language'],
-                                                                              ['Type', 'metadata_type'],
-                                                                              ['Identifier', 'metadata_identifier'],
-                                                                              ['Publisher', 'metadata_publisher'],
-                                                                              ['Format', 'metadata_format'],
-                                                                              ['Rights', 'metadata_rights'],
-                                                                              ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
-                    .row.g-2
-                      .col-sm-7 
-                        = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term')
-                      .col-sm-3
-                      
-                      
+                #advanced-search-row-template{style: 'display:none'}
+                  .row.g-2.mb-2
+                    .col-sm-2 
+                      = select_tag('criteria[N][operator]', options_for_select([['and', 'AND'], ['or', 'OR'], ['not', 'NOT']], 'AND'), 
+                                                                                class: 'form-select')
+                    .col-sm-10 
+                      = select_tag('criteria[N][field]', options_for_select([['Keyword', 'search_all'], 
+                                                                            ['Title', 'metadata_title'],
+                                                                            ['Creator', 'metadata_creator'],
+                                                                            ['Contributor', 'metadata_contributor'],
+                                                                            ['Subject', 'metadata_subject'], 
+                                                                            ['Description', 'metadata_description'],
+                                                                            ['Date', 'metadata_date'],
+                                                                            ['Language', 'metadata_language'],
+                                                                            ['Type', 'metadata_type'],
+                                                                            ['Identifier', 'metadata_identifier'],
+                                                                            ['Publisher', 'metadata_publisher'],
+                                                                            ['Format', 'metadata_format'],
+                                                                            ['Rights', 'metadata_rights'],
+                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
+                  .row.g-2
+                    .col-sm-7 
+                      = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term')
+                    .col-sm-3
+                      = select_tag('criteria[N][match]', options_for_select([['All of the words', 'all'], 
+                                                                            ['Any of the words', 'any'], 
+                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
+                    .col-sm-2
+                      %button.btn.btn-outline-danger.btn-sm.remove-advanced-row-btn{type: 'button'} &minus; Remove
+          .d-flex.justify-content-end.mb-3 
+            %button.btn.btn-outline-secondary{type: 'button', id: 'add-advanced-search-row'} 
+              &plus; Add Row
+          %hr
+          .d-flex.justify-content-end.gap-2
+            %button.btn.btn-outline-secondary{type: 'button', id: 'advanced-search-clear'} Clear
+            = submit_tag('Search', class: 'btn btn-primary', id: 'advanced-search-submit')


### PR DESCRIPTION
First iteration of the actual Advanced Search tab for the DL: [issue 6](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=7322639&issue=medusa-project%7Cdigital-library-issues%7C6)

## Summary of Changes:

- Advanced Search tab pane with a multi-row boolean search form: first row is permanent; additional rows are added dynamically from a hidden template
  - Each row has: field dropdown `(Keyword, Title, Creator, Contributor, Subject, Description, Date, Language, Type, Identifier, Publisher, Format, Rights, Spatial Coverage)`, free-text input, and match type dropdown `(All of the words, Any of the words, Exact phrase, Fuzzy match)`
- Additional rows include a boolean operator selector `(AND / OR / NOT)`
- `Add Row` and `Remove` buttons for dynamic row management
- Clear button resets the form to initial state
-  All query logic moved to the backend
- `AbstractRelation: query_clauses` state and builder method + `query_clauses_hash` helper that produces the correct OpenSearch sub-query per match type
  - Match types include: `simple_query_string`, `match_phrase`, fuzzy
- `ItemRelation `+ `CollectionRelation`: modifies `build_query` with `must/should/must_not` clauses to refine boolean search

## Local Testing
<img width="1444" height="780" alt="Screenshot 2026-06-04 at 8 04 04 AM" src="https://github.com/user-attachments/assets/2d9008fc-0bb4-4891-ae05-8d66a7922c09" />

> Advanced Search tab landing view includes all items/collections and facets with default advanced search row 

<img width="1249" height="619" alt="Screenshot 2026-06-04 at 8 15 07 AM" src="https://github.com/user-attachments/assets/104ecf6c-c3c1-4c3f-8dcf-d5a66a6b6180" />

> Dropdown field options

<img width="1156" height="557" alt="Screenshot 2026-06-04 at 8 16 10 AM" src="https://github.com/user-attachments/assets/644eb284-ae4e-457d-b46d-d610774a1471" />

> Dropdown match criteria options including Fuzzy Search


https://github.com/user-attachments/assets/2100e1ea-c5dc-46cd-b831-9e8dbf6b6f22

> Screencast sample search

