### PR TITLE
Adv search UI Changes

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -91,54 +91,19 @@ const Application = {
 
     initAdvancedSearch: function() {
         const form = document.getElementById('advanced-search-form');
-        if (!form) {
-            return;
-        }
-        const criteria = document.getElementById('advanced-search-criteria');
-        const template = document.getElementById('advanced-search-row-template');
-        const addBtn = document.getElementById('add-advanced-search-row');
+        if (!form) { return; }
         const clearBtn = document.getElementById('advanced-search-clear');
 
-        let rowIndex = 1; 
-
-        addBtn.addEventListener('click', function() {
-            const clone = template.cloneNode(true);
-            clone.removeAttribute('id');
-            clone.classList.add('advanced-search-row');
-            clone.style.display = '';
-            clone.querySelectorAll('input, select').forEach(function(element) {
-                element.disabled = false;
-            });
-            clone.innerHTML = clone.innerHTML.replaceAll('[N]', '[' + rowIndex + ']');
-            criteria.appendChild(clone);
-            rowIndex++;
-        });
-
-        criteria.addEventListener('click', function(e) {
-          if (e.target.closest('.remove-advanced-row-btn')) {
-            e.target.closest('.advanced-search-row').remove();
-          }
-        });
-
         clearBtn.addEventListener('click', function() {
-          document.querySelectorAll('#advanced-search-criteria .advanced-search-row').forEach(function(row) {
-            if (row.dataset.row === '0') {
-              row.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
-              row.querySelector('input[type="text"]').value = '';
-            } else {
-              row.remove();
-            }
+          form.querySelectorAll('input[name^="criteria["]').forEach(function(input) {
+            input.value = '';
           });
-          rowIndex = 1;
         });
 
         form.addEventListener('submit', function(e) {
           e.preventDefault();
-          const rows = criteria.querySelectorAll('.advanced-search-row');
-          let hasQuery = false;
-          rows.forEach(function(row) {
-            if (row.querySelector('input[type="text"]').value.trim()) hasQuery = true;
-          });
+          const hasQuery = Array.from(form.querySelectorAll('input[name^="criteria["]'))
+            .some(function(input) { return input.value.trim() !== ''; });
           if (!hasQuery) return;
           form.submit();
         });

--- a/app/search/abstract_relation.rb
+++ b/app/search/abstract_relation.rb
@@ -163,7 +163,7 @@ class AbstractRelation
   ##
   # Adds a multi-clause boolean query for field-specific advanced search.
   #
-  # @param clauses [Array<Hash>] Each hash has :field, :query, :match, :operator keys
+  # @param clauses [Array<Hash>] Each hash has :field, :query, and :match keys
   # @return [self]
   #
   def query_clauses(clauses)

--- a/app/search/collection_relation.rb
+++ b/app/search/collection_relation.rb
@@ -121,19 +121,8 @@ class CollectionRelation < AbstractRelation
   # @return [String] JSON string.
   #
   def build_query
-    # Pre-compute criteria clause arrays for multi-field boolean search
-    criteria_must, criteria_should, criteria_must_not = [], [], []
-    if @query_clauses.present?
-      @query_clauses.each_with_index do |clause, idx|
-        ch = build_clause_hash(clause[:field], clause[:query], clause[:match])
-        op = (idx == 0) ? 'AND' : clause[:operator].to_s.upcase
-        case op
-        when 'OR'  then criteria_should << ch
-        when 'NOT' then criteria_must_not << ch
-        else            criteria_must << ch
-        end
-      end
-    end
+    # Pre-compute must clauses for multi-field boolean search (all fields AND'd)
+    criteria_must = @query_clauses.present? ? @query_clauses.map { |c| build_clause_hash(c[:field], c[:query], c[:match]) } : []
 
     Jbuilder.encode do |j|
       j.track_total_hits true
@@ -141,11 +130,7 @@ class CollectionRelation < AbstractRelation
         j.bool do
           # Query
           if @query_clauses.present?
-            j.must criteria_must unless criteria_must.empty?
-            unless criteria_should.empty?
-              j.should criteria_should
-              j.minimum_should_match 1 unless criteria_must.any?
-            end
+            j.must criteria_must
           elsif @query.present?
             j.must do
               # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
@@ -227,9 +212,6 @@ class CollectionRelation < AbstractRelation
                 j.exists do
                   j.field Collection::IndexFields::PARENT_COLLECTIONS
                 end
-              end
-              criteria_must_not.each do |clause_hash|
-                j.child! { j.merge!(clause_hash) }
               end
             end
           end

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -165,19 +165,8 @@ class ItemRelation < AbstractRelation
   def build_query
     collections_array = @collections ? Array(@collections).flatten.compact : nil
 
-    # Pre-compute criteria clause arrays for multi-field boolean search
-    criteria_must, criteria_should, criteria_must_not = [], [], []
-    if @query_clauses.present?
-      @query_clauses.each_with_index do |clause, idx|
-        ch = build_clause_hash(clause[:field], clause[:query], clause[:match])
-        op = (idx == 0) ? 'AND' : clause[:operator].to_s.upcase
-        case op
-        when 'OR'  then criteria_should << ch
-        when 'NOT' then criteria_must_not << ch
-        else            criteria_must << ch
-        end
-      end
-    end
+    # Pre-compute must clauses for multi-field boolean search (all fields AND'd)
+    criteria_must = @query_clauses.present? ? @query_clauses.map { |c| build_clause_hash(c[:field], c[:query], c[:match]) } : []
 
     Jbuilder.encode do |j|
       j.track_total_hits true
@@ -185,11 +174,7 @@ class ItemRelation < AbstractRelation
         j.bool do
           # Query
           if @query_clauses.present?
-            j.must criteria_must unless criteria_must.empty?
-            unless criteria_should.empty?
-              j.should criteria_should
-              j.minimum_should_match 1 unless criteria_must.any?
-            end
+            j.must criteria_must
           elsif @query.present?
             j.must do
               if !@exact_match
@@ -330,7 +315,7 @@ class ItemRelation < AbstractRelation
             j.minimum_should_match 1
           end
 
-          if @exclude_variants.any? || (!@include_children_in_results && !@search_children) || criteria_must_not.any?
+          if @exclude_variants.any? || (!@include_children_in_results && !@search_children)
             j.must_not do
               if @exclude_variants.any?
                 j.child! do
@@ -346,10 +331,6 @@ class ItemRelation < AbstractRelation
                     j.field Item::IndexFields::PARENT_ITEM
                   end
                 end
-              end
-
-              criteria_must_not.each do |clause_hash|
-                j.child! { j.merge!(clause_hash) }
               end
             end
           end

--- a/app/search/simple_item_search.rb
+++ b/app/search/simple_item_search.rb
@@ -30,6 +30,7 @@ class SimpleItemSearch < ItemRelation
     include_unpublished(false)
     include_restricted(false)
     include_publicly_inaccessible(false)
+    search_children(true)
 
     if @search_query.present?
       query_all(@search_query)

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -109,29 +109,33 @@ class SpecialCollectionSearch
 
   private
   
+  FIELD_MAP = {
+    'keyword'          => 'search_all',
+    'title'            => 'metadata_title',
+    'creator'          => 'metadata_creator',
+    'contributor'      => 'metadata_contributor',
+    'subject'          => 'metadata_subject',
+    'description'      => 'metadata_description',
+    'date'             => 'metadata_date',
+    'language'         => 'metadata_language',
+    'type'             => 'metadata_type',
+    'identifier'       => 'metadata_identifier',
+    'publisher'        => 'metadata_publisher',
+    'format'           => 'metadata_format',
+    'rights'           => 'metadata_rights',
+    'spatial_coverage' => 'metadata_spatialCoverage'
+  }.freeze
+
   ##
-  # Converts the @criteria params hash (keyed by row index) into an array of
+  # Converts the @criteria params hash (named field keys) into an array of
   # clause hashes suitable for AbstractRelation#query_clauses.
   #
   def build_criteria_clauses
     return [] unless @criteria.present?
-
-    allowed_fields = %w[search_all metadata_title metadata_creator metadata_contributor
-                        metadata_subject metadata_description metadata_date metadata_language
-                        metadata_type metadata_identifier metadata_publisher metadata_format
-                        metadata_rights metadata_spatialCoverage]
-    allowed_matches = %w[all any phrase]
-    allowed_operators = %w[AND OR NOT]
-
-    @criteria.to_unsafe_h.sort_by { |k, _| k.to_i }.filter_map do |_idx, row|
-      query_text = row['query'].to_s.strip
+    FIELD_MAP.filter_map do |key, field|
+      query_text = @criteria[key].to_s.strip
       next if query_text.blank?
-
-      field    = allowed_fields.include?(row['field']) ? row['field'] : 'search_all'
-      match    = allowed_matches.include?(row['match']) ? row['match'] : 'all'
-      operator = allowed_operators.include?(row['operator']&.upcase) ? row['operator'].upcase : 'AND'
-
-      { field: field, query: query_text, match: match, operator: operator }
+      { field: field, query: query_text, match: 'all', operator: 'AND' }
     end
   end
 

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -96,73 +96,67 @@
         = form_tag(search_landing_path, method: :get, id: 'advanced-search-form') do
           = hidden_field_tag(:tab, 'advanced-search')
           = hidden_field_tag(:q, '')
+          - adv = @permitted_params[:criteria] || {}
 
-          .card.mb-3 
-            .card-body
-              %h6.fw-bold.mb-3 Enter Search Term:
+          .mb-2
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Keyword
+              .col-sm-9
+                = text_field_tag('criteria[keyword]', adv['keyword'], class: 'form-control', placeholder: 'Search across all fields')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Title
+              .col-sm-9
+                = text_field_tag('criteria[title]', adv['title'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Creator
+              .col-sm-9
+                = text_field_tag('criteria[creator]', adv['creator'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Contributor
+              .col-sm-9
+                = text_field_tag('criteria[contributor]', adv['contributor'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Subject
+              .col-sm-9
+                = text_field_tag('criteria[subject]', adv['subject'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Description
+              .col-sm-9
+                = text_field_tag('criteria[description]', adv['description'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Date
+              .col-sm-9
+                = text_field_tag('criteria[date]', adv['date'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Language
+              .col-sm-9
+                = text_field_tag('criteria[language]', adv['language'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Type
+              .col-sm-9
+                = text_field_tag('criteria[type]', adv['type'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Identifier
+              .col-sm-9
+                = text_field_tag('criteria[identifier]', adv['identifier'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Publisher
+              .col-sm-9
+                = text_field_tag('criteria[publisher]', adv['publisher'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Format
+              .col-sm-9
+                = text_field_tag('criteria[format]', adv['format'], class: 'form-control')
+            .row.align-items-center.py-2.border-bottom
+              %label.col-sm-3.col-form-label.fw-semibold Rights
+              .col-sm-9
+                = text_field_tag('criteria[rights]', adv['rights'], class: 'form-control')
+            .row.align-items-center.py-2
+              %label.col-sm-3.col-form-label.fw-semibold Spatial Coverage
+              .col-sm-9
+                = text_field_tag('criteria[spatial_coverage]', adv['spatial_coverage'], class: 'form-control')
 
-              #advanced-search-criteria 
-
-                .advanced-search-row{data: {row:'0'}}
-                  .row.g-2.mb-2
-                    .col-12 
-                      = select_tag('criteria[0][field]', options_for_select([['Keyword', 'search_all'], 
-                                                                            ['Title', 'metadata_title'],
-                                                                            ['Creator', 'metadata_creator'],
-                                                                            ['Contributor', 'metadata_contributor'],
-                                                                            ['Subject', 'metadata_subject'], 
-                                                                            ['Description', 'metadata_description'],
-                                                                            ['Date', 'metadata_date'],
-                                                                            ['Language', 'metadata_language'],
-                                                                            ['Type', 'metadata_type'],
-                                                                            ['Identifier', 'metadata_identifier'],
-                                                                            ['Publisher', 'metadata_publisher'],
-                                                                            ['Format', 'metadata_format'],
-                                                                            ['Rights', 'metadata_rights'],
-                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select')
-                  
-                  .row.g-2 
-                    .col-sm-8 
-                      = text_field_tag('criteria[0][query]', nil, class: 'form-control', placeholder: 'Enter search term')
-                    .col-sm-4 
-                      = select_tag('criteria[0][match]', options_for_select([['All of the words', 'all'], 
-                                                                            ['Any of the words', 'any'], 
-                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select')
-
-                #advanced-search-row-template{style: 'display:none'}
-                  .row.g-2.mb-2
-                    .col-sm-2 
-                      = select_tag('criteria[N][operator]', options_for_select([['and', 'AND'], ['or', 'OR'], ['not', 'NOT']], 'AND'), 
-                                                                                class: 'form-select', disabled: true)
-                    .col-sm-10 
-                      = select_tag('criteria[N][field]', options_for_select([['Keyword', 'search_all'], 
-                                                                            ['Title', 'metadata_title'],
-                                                                            ['Creator', 'metadata_creator'],
-                                                                            ['Contributor', 'metadata_contributor'],
-                                                                            ['Subject', 'metadata_subject'], 
-                                                                            ['Description', 'metadata_description'],
-                                                                            ['Date', 'metadata_date'],
-                                                                            ['Language', 'metadata_language'],
-                                                                            ['Type', 'metadata_type'],
-                                                                            ['Identifier', 'metadata_identifier'],
-                                                                            ['Publisher', 'metadata_publisher'],
-                                                                            ['Format', 'metadata_format'],
-                                                                            ['Rights', 'metadata_rights'],
-                                                                            ['Spatial Coverage', 'metadata_spatialCoverage']]), class: 'form-select', disabled: true)
-                  .row.g-2
-                    .col-sm-7 
-                      = text_field_tag('criteria[N][query]', nil, class: 'form-control', placeholder: 'Enter search term', disabled: true)
-                    .col-sm-3
-                      = select_tag('criteria[N][match]', options_for_select([['All of the words', 'all'], 
-                                                                            ['Any of the words', 'any'], 
-                                                                            ['Exact phrase', 'phrase']], 'all'), class: 'form-select', disabled: true)
-                    .col-sm-2
-                      %button.btn.btn-outline-danger.btn-sm.remove-advanced-row-btn{type: 'button'} &minus; Remove
-          .d-flex.justify-content-end.mb-3 
-            %button.btn.btn-outline-secondary{type: 'button', id: 'add-advanced-search-row'} 
-              &plus; Add Row
-          %hr
-          .d-flex.justify-content-end.gap-2
+          .d-flex.justify-content-end.gap-2.mt-3
             %button.btn.btn-outline-secondary{type: 'button', id: 'advanced-search-clear'} Clear
             = submit_tag('Search', class: 'btn btn-primary', id: 'advanced-search-submit')
 


### PR DESCRIPTION
- Rework the Advanced Search UI to be more like Ideals, with all search options available as text fields on one screen
- Remove add/remove row logic
- Remove boolean operators (every query is defaulted to '`AND'`)
- Remove match types (apply `fuzziness: AUTO` as query-time feature to handle misspellings within 2 characters, including words with up to 2 diacritics)

<img width="1425" height="963" alt="Screenshot 2026-06-10 at 8 21 41 AM" src="https://github.com/user-attachments/assets/101fe680-7b21-4dd0-beb9-b36268f27091" />
