### PR TITLE
Repository description field

### DIFF
--- a/app/views/repositories/show.html.haml
+++ b/app/views/repositories/show.html.haml
@@ -11,7 +11,8 @@
           = submit_tag("Search", class: "btn btn-primary")
 
 %h1.mt-5= @repository.title
-%p.lead= 'Insert Repository Description Here'
+- if @repository.description.present?
+  %p.lead= @repository.description
 
 - if @permitted_params[:q].present?
   :javascript

--- a/config/initializers/medusa_client.rb
+++ b/config/initializers/medusa_client.rb
@@ -9,3 +9,35 @@ Medusa::Client.configuration = {
     medusa_user:     config.medusa_user,
     medusa_secret:   config.medusa_secret
 }
+
+# Temporary patch to expose public_description from the Medusa repository JSON.
+# Remove this once medusa-client gem is updated to include it natively.
+Medusa::Repository.class_eval do
+  def description
+    load
+    @description
+  end
+
+  private
+
+  def load
+    return if @loading || @loaded
+    @loading           = true
+    struct             = fetch_body
+    @contact_email     = struct['contact_email']
+    @description       = struct['public_description']
+    @email             = struct['email']
+    @home_url          = struct['url']
+    @id                = struct['id']
+    @ldap_admin_domain = struct['ldap_admin_domain']
+    @ldap_admin_group  = struct['ldap_admin_group']
+    @title             = struct['title']
+    @uuid              = struct['uuid']
+    struct['collections'].each do |col_struct|
+      @collections << Medusa::Collection.with_id(col_struct['id'])
+    end
+    @loaded = true
+  ensure
+    @loading = false
+  end
+end


### PR DESCRIPTION
Related to [Medusa issue 65](https://github.com/medusa-project/medusa-issues/issues/65#issuecomment-4674096180) - Pulls new `public description field `from `medusa repository`:

- Exposes the field inside the `medusa_client config `and renders view in `repository show pages`
- **_N.B.:_** kumquat's medusa config only accepts production data, regardless of kumquat environment, so any public description fields added in medusa demo will **not** display in DL demo

<img width="2180" height="1452" alt="image" src="https://github.com/user-attachments/assets/e64dec8a-1eb3-4b65-b804-0fd40cced2c1" />
<img width="2074" height="768" alt="image" src="https://github.com/user-attachments/assets/5fd82abc-1d47-42ca-9917-b3e82bd7c25e" />

 _**Future refactor:** update the `medusa-client gem` directly and release a new tag, then remove this patch from the initializer in kumquat_. 