### PR TITLE
Exclude Known Bot activity from triggering System Error emails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,7 @@ class ApplicationController < ActionController::Base
                                         user:      current_user)
     Rails.logger.error(@message)
 
-    unless Rails.env.development?
+    unless Rails.env.development? || Crawler.matches?(request.user_agent)
       KumquatMailer.error(@message).deliver_now
     end
 

--- a/app/util/crawler.rb
+++ b/app/util/crawler.rb
@@ -1,0 +1,15 @@
+##
+# Crawler class to load and memoize the content of crawlers.yml file.
+# 
+
+class Crawler 
+  ## 
+  # begin..end block to memoize user_agents array to avoid reloading multiple times
+  # load crawlers.yml content or return an empty array if no file found 
+  # iterate over the crawler.yml file entries, convert to string, strip whitespace, downcase and reject blank entries
+  def self.user_agents
+    @user_agents ||= begin
+      entries = YAML.load_file(Rails.root.join('config', 'crawlers.yml')) || []
+      entries.map { |user_agent| user_agent.to_s.strip.downcase }.reject(&:blank?)
+    end
+  end

--- a/app/util/crawler.rb
+++ b/app/util/crawler.rb
@@ -25,3 +25,4 @@ class Crawler
     ua = user_agent.downcase 
     user_agents.any? { | crawler| ua.include?(crawler) }
   end
+end

--- a/app/util/crawler.rb
+++ b/app/util/crawler.rb
@@ -5,11 +5,23 @@
 class Crawler 
   ## 
   # begin..end block to memoize user_agents array to avoid reloading multiple times
-  # load crawlers.yml content or return an empty array if no file found 
+  # load crawlers.yml content; empty file yields an empty array,
+  # while a missing file raises Errno::ENOENT (fails loudly). This would happen if the file was deleted/moved, 
+  # or not deployed for some reason.
   # iterate over the crawler.yml file entries, convert to string, strip whitespace, downcase and reject blank entries
   def self.user_agents
     @user_agents ||= begin
       entries = YAML.load_file(Rails.root.join('config', 'crawlers.yml')) || []
       entries.map { |user_agent| user_agent.to_s.strip.downcase }.reject(&:blank?)
     end
+  end
+
+  def self.matches?(user_agent)
+    # false for blank user agent
+    return false if user_agent.blank?
+
+    # otherwise downcase the given user agent 
+    # and check if it includes any of the elements in the user_agents array
+    ua = user_agent.downcase 
+    user_agents.any? { | crawler| ua.include?(crawler) }
   end

--- a/config/crawlers.yml
+++ b/config/crawlers.yml
@@ -1,0 +1,17 @@
+# User-Agent substrings are treated as known bots/crawlers. 
+# If a request's User-Agent header contains any of these substrings, 
+# it will NOT trigger an admin "System Error" email.
+# The error will still be logged and rendered in the error page, 
+# but it will not be sent to the admin email address.
+
+- ClaudeBot
+- Anthropic
+- Applebot
+- Bingbot
+- AhrefsBot
+- SemrushBot
+- DataforseoBot
+- SogouwebSpider
+- FeedValidator
+- DuckDuckBot
+- Googlebot

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require 'mocha/minitest'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @item = items(:compound_object_1001)
+    setup_opensearch
+  end
+
+  # rescue_internal_server_error()
+
+  test 'rescue_internal_server_error does not email admins for known bot User-Agents' do 
+
+    # Stub ItemsController#index action to raise an exception
+
+    ItemsController.any_instance.stubs(:index).raises(StandardError, 'test error')
+
+    # Simulate a GET request to items_path with a user agent with a bot User-Agent header (e.g., Googlebot)
+    # Assert NO email is sent to admin
+    
+    assert_no_emails do 
+      get items_path, headers: { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' }
+    end
+    assert_response :internal_server_error
+  end
+
+  test 'rescue_internal_server_error emails admins for non-bot User-Agents' do 
+
+    # Stub ItemsController#index action to raise an exception
+
+    ItemsController.any_instance.stubs(:index).raises(StandardError, 'test error')
+
+    # Simulate a GET request to items_path with a user agent with a non-bot User-Agent header (e.g., Mozilla/5.0)
+    # Assert 1 email is sent/delivered to admin
+
+    assert_emails 1 do 
+      get items_path, headers: { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36' }
+    end
+    assert_response :internal_server_error
+  end
+end

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -22,7 +22,13 @@ class CrawlerTest < ActiveSupport::TestCase
   end
 
   test 'missing file raises Errno::ENOENT' do
-    #todo
+    
+    Crawler.instance_variable_set(:@user_agents, nil)
+    YAML.stubs(:load_file).raises(Errno::ENOENT)
+
+    assert_raises(Errno::ENOENT) { Crawler.user_agents }
+  ensure
+    Crawler.instance_variable_set(:@user_agents, nil) # memoized nil value is cleared to avoid affecting other tests
   end
 
   test 'matches? returns false if user agent is blank' do 

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -5,7 +5,7 @@ class CrawlerTest < ActiveSupport::TestCase
 
   test 'user_agents returns non empty array based on crawlers.yml content' do 
     
-    crawlers = Crawlers.user_agents
+    crawlers = Crawler.user_agents
 
     assert_instance_of Array, crawlers
     assert_not_empty crawlers

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -1,17 +1,33 @@
 require 'test_helper'
+require 'mocha/minitest'
 
 class CrawlerTest < ActiveSupport::TestCase 
 
   test 'user_agents returns non empty array based on crawlers.yml content' do 
     
     crawlers = Crawlers.user_agents
+
     assert_instance_of Array, crawlers
     assert_not_empty crawlers
+  end
 
+  test 'empty file yields empty array' do
+
+    Crawler.instance_variable_set(:@user_agents, nil)
+    YAML.stubs(:load_file).returns(nil)
+  
+    assert_empty Crawler.user_agents
+  ensure
+    Crawler.instance_variable_set(:@user_agents, nil) # memoized nil value is cleared to avoid affecting other tests
+  end
+
+  test 'missing file raises Errno::ENOENT' do
+    #todo
   end
 
   test 'matches? returns false if user agent is blank' do 
-    #todo
+    ua = ''
+    assert false, Crawler.matches?(ua)
   end
 
   test 'matches? returns true if user agent matches any crawler element' do 

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -26,8 +26,8 @@ class CrawlerTest < ActiveSupport::TestCase
   end
 
   test 'matches? returns false if user agent is blank' do 
-    ua = ''
-    assert_equal false, Crawler.matches?(ua)
+    assert_equal false, Crawler.matches?('')
+    assert_equal false, Crawler.matches?(nil)
   end
 
   test 'matches? returns true if user agent matches any crawler element' do 

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -27,11 +27,12 @@ class CrawlerTest < ActiveSupport::TestCase
 
   test 'matches? returns false if user agent is blank' do 
     ua = ''
-    assert false, Crawler.matches?(ua)
+    assert_equal false, Crawler.matches?(ua)
   end
 
   test 'matches? returns true if user agent matches any crawler element' do 
-    #todo
+    ua = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+    assert_equal true, Crawler.matches?(ua)
   end
 
 end

--- a/test/util/crawler_test.rb
+++ b/test/util/crawler_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class CrawlerTest < ActiveSupport::TestCase 
+
+  test 'user_agents returns non empty array based on crawlers.yml content' do 
+    
+    crawlers = Crawlers.user_agents
+    assert_instance_of Array, crawlers
+    assert_not_empty crawlers
+
+  end
+
+  test 'matches? returns false if user agent is blank' do 
+    #todo
+  end
+
+  test 'matches? returns true if user agent matches any crawler element' do 
+    #todo
+  end
+
+end


### PR DESCRIPTION
Addresses [Issue 211](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=207922347&issue=medusa-project%7Cdigital-library-issues%7C211) - known bots `(e.g. Googlebot, Bingbot, Anthropic, etc.)` have been crawling the digital library `/items` pages, making many requests at a time and raising internal errors that result in an email to admin for every error raised, crowding admin inboxes. 

## Summary of Changes:
- a flat `YAML` file of known `bot User-Agents`
- a `Crawler utility class` that loads the YAML file and memoizes the content to avoid reloads, providing a usable `array of known user agents`
- Crawler class finds `matches based on the given user agent` against the array
- Inside the `Application Controller,` the `.matches?() method is added as a guard` in the `rescue_internal_server_error()` method to prevent system error emails from being delivered
- The errors are still logged normally and will still be available in Splunk, but the hope is this reduces alerts for us

## Testing:
- `Crawler Utility Tests` validity of the array of user agents
  - Simulates an empty YAML file returning nil
  - Simulates a missing YAML file raising No such file directory error (Errno::ENOENT)
  - Tests matches?() method returning false if user agent is blank and returning true when user agent matches any crawler entity
- `Application Controller Tests` stub an error raised in the `Items Controller` index action, simulating a `GET` request to the `items_path` with a known user agent and asserting that `no emails are sent`
  - Stubs the same error and request, this time with an unknown user agent, `asserting 1 email is sent`