### PR TITLE
Prevent bots from exceeding the max allowed start pagination

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_not_found
   rescue_from NotAuthorizedError, with: :rescue_unauthorized
 
+  before_action :validate_start_param
+
   protected
 
   ##
@@ -223,6 +225,12 @@ class ApplicationController < ActionController::Base
   def rescue_unknown_format
     render plain: "Sorry, we aren't able to provide the requested format.",
            status: :unsupported_media_type
+  end
+
+  def validate_start_param
+    if params[:start].present? && params[:start].to_i >= OpensearchClient::MAX_RESULT_WINDOW
+      render plain: "The 'start' parameter exceeds the maximum allowed value of #{OpensearchClient::MAX_RESULT_WINDOW}.", status: :bad_request
+    end
   end
 
 end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -62,7 +62,7 @@ class RepositoriesController < WebsiteController
       
       # Handle search if query is present
       if @permitted_params[:q].present?
-        @start = [@permitted_params[:start].to_i.abs, max_start].min 
+        @start = @permitted_params[:start].to_i
         @limit = window_size
 
         # Repository-scoped search
@@ -103,9 +103,5 @@ class RepositoriesController < WebsiteController
 
   def window_size
     40 
-  end
-
-  def max_start
-    9960 
   end
 end

--- a/app/controllers/search_landing_controller.rb
+++ b/app/controllers/search_landing_controller.rb
@@ -9,7 +9,7 @@ class SearchLandingController < WebsiteController
     # Get total available counts for display
     @total_available_count = total_available_dls_count
     
-    @start = [@permitted_params[:start].to_i.abs, max_start].min
+    @start = @permitted_params[:start].to_i
     @limit = window_size
 
     # Use unified search for both collections and items
@@ -52,9 +52,5 @@ class SearchLandingController < WebsiteController
 
   def window_size 
     40 
-  end
-
-  def max_start 
-    9960 
   end
 end

--- a/app/controllers/special_collections_search_controller.rb
+++ b/app/controllers/special_collections_search_controller.rb
@@ -14,7 +14,7 @@ class SpecialCollectionsSearchController < WebsiteController
       return 
     end
 
-    @start = [@permitted_params[:start].to_i.abs, max_start].min 
+    @start = @permitted_params[:start].to_i
     @limit = window_size
 
     # Unified search for both collections and items
@@ -48,9 +48,5 @@ class SpecialCollectionsSearchController < WebsiteController
 
   def window_size 
     40 
-  end
-
-  def max_start
-    9960
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -39,4 +39,41 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :internal_server_error
   end
+
+  test 'validate_start_param returns bad request for start param exceeding max value' do
+
+    # Simulate a GET request to items_path with a start param exceeding the max allowed value by 1
+    # Assert bad request and response message
+
+    get items_path, params: { q: 'test', start: OpensearchClient::MAX_RESULT_WINDOW + 1 }
+    assert_response :bad_request
+    assert_match /The 'start' parameter exceeds the maximum allowed value/, response.body
+  end
+
+  test 'validate_start_param allows start param within max value' do
+
+    # Simulate a GET request to items_path with a valid start param
+    # Assert success response
+    
+    get items_path, params: { q: 'test', start: 10 }
+    assert_response :success
+  end
+
+  test 'validate_start_param allows for start of 0' do
+
+    # Simulate a GET request to items_path with a start param of 0
+    # Assert success response
+    
+    get items_path, params: { q: 'test', start: 0 }
+    assert_response :success
+  end
+
+  test 'validate_start_param handles non numeric strings gracefully' do
+
+    # Simulate a GET request to items_path with a non-numeric start param
+    # Assert success response
+    
+    get items_path, params: { q: 'test', start: 'abc' }
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Receiving large volume of system errors related to bots crawling our atom feeds and setting pagination start values much higher than the max allowed limit - [issue 215](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=227054759&issue=medusa-project%7Cdigital-library-issues%7C215)

## Summary of Changes:
- Add a `before_action :validate_start_param` in `ApplicationController` that applies to all controllers
- returns `400 bad request` if `params[:start]` exceeds `OpensearchClient::MAX_RESULT_WINDOW,` stopping request before it reaches `OpenSearch` and preventing system alert
- Remove dead-code `max_start` methods from `SearchLandingController, RepositoriesController, and SpecialCollectionsSearchController` (these are not on prod yet, but better to address now)

## Tests:
- `Validation tests` check how the `before_action `guard behaves when the `start param` is beyond the `max limit (bad request)`, `within the limit (success)`, `default of 0 (success)`, and how it handles `non-numeric strings (defaults to 0; success instead of breaking)`
