### PR TITLE
Advanced Search UI Updates (Feature-6)

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -94,17 +94,57 @@ const Application = {
         if (!form) { return; }
         const clearBtn = document.getElementById('advanced-search-clear');
 
+        // Wire change listener to each field dropdown. 
+        // When fired it traverses up the DOM to find the corresponding .row, 
+        // finds the [data-critera-input] text and updates its name attribute.
+
+        form.querySelectorAll('[data-criteria-field-select]').forEach(function(select) {
+          select.addEventListener('change', function() {
+            const row = this.closest('.row');
+            const input = row.querySelector('[data-criteria-input]');
+            if (input) {
+              input.name = 'criteria[' + this.value + ']';
+            }
+          });
+        });
+
         clearBtn.addEventListener('click', function() {
           form.querySelectorAll('input[name^="criteria["]').forEach(function(input) {
             input.value = '';
           });
+
+          // Reset dropdown select to defaul values and re-sync the input names when clearing the form
+          form.querySelectorAll('[data-criteria-field-select]').forEach(function(select) {
+            const defaultValue = select.dataset.default;
+            select.value = defaultValue;
+            const row = select.closest('.row');
+            const input = row.querySelector('[data-criteria-input]');
+            if (input) {
+              input.name = 'criteria[' + select.value + ']';
+            }
+          });
+
+          // Reset the Rights dropdown to default (select/blank)
+          const rightsSelect = form.querySelector('select[name="criteria[rights]"]');
+          if (rightsSelect) {
+            rightsSelect.value = '';
+          }
         });
 
         form.addEventListener('submit', function(e) {
           e.preventDefault();
-          const hasQuery = Array.from(form.querySelectorAll('input[name^="criteria["]'))
+
+          // Extend the submt logic to check for select in addition to input fields
+          const hasTextQuery = Array.from(form.querySelectorAll('input[name^="criteria["]'))
             .some(function(input) { return input.value.trim() !== ''; });
-          if (!hasQuery) return;
+          
+          const rightsSelect = form.querySelector('select[name="criteria[rights]"]');
+          const hasRightsQuery = rightsSelect && rightsSelect.value.trim() !== '';
+
+          if (!hasTextQuery && !hasRightsQuery) return;
+          form.querySelectorAll('[data-criteria-field-select]').forEach(function(select) {
+              select.disabled = true;
+          });
           form.submit();
         });
     },

--- a/app/assets/stylesheets/search_landing.scss
+++ b/app/assets/stylesheets/search_landing.scss
@@ -19,6 +19,64 @@
   z-index: 2;
 }
 
+.browse-tile-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.browse-flip-card {
+  width: 100%;
+  max-width: 200px;
+  margin: 0 auto;
+  aspect-ratio: 1 / 1;
+  perspective: 1000px;
+}
+
+.browse-flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.browse-flip-card:hover .browse-flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.browse-flip-card-front, .browse-flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.375rem;
+  padding: 1rem;
+  text-align: center;
+  h3 {
+    font-size: 1rem;
+  }
+
+  p {
+    font-size: 0.8rem;
+  }
+}
+
+.browse-flip-card-front {
+  background-color: #13294B; // Illinois Blue
+  color: #fff;
+}
+  
+.browse-flip-card-back {
+  background-color: #C94120; // Illinois Orange
+  color: #fff;
+  transform: rotateY(180deg);
+}
+
 #advanced-search-link:focus {
   outline: 3px solid #FF552E; // Illinois Orange
   outline-offset: 2px;

--- a/app/search/abstract_relation.rb
+++ b/app/search/abstract_relation.rb
@@ -288,10 +288,13 @@ class AbstractRelation
   #
   def build_clause_hash(field, query_text, match_type)
     case match_type.to_s
-    # when 'phrase'
-    #   { 'match_phrase' => { field => query_text } }
-    # when 'any'
-    #   { 'simple_query_string' => { 'query' => query_text, 'fields' => [field], 'default_operator' => 'OR', 'lenient' => true } }
+    
+    # exact match for Rights field, avoids 'stop' words inside opensearch index schema. E.g. "In Copyright" has "in" as a stop word,
+    # so the query becomes just "copyright" and returns all results with "copyright" in the Rights field, instead of just the exact match.
+    # adding a term query fix against the metadata_rights.keyword, bypasses the custom analyzer and returns exact matching without using
+    # tokenization, stemming or stop words. 
+    when 'term'
+      { 'term' => { "#{field}.keyword" => query_text } } 
     when 'exact' # exact match (no fuzziness applied for keys like date, language, spatial_coverage)
       { 'match' => { field => { 'query' => query_text, 'operator' => 'AND', 'lenient' => true } } }
     else # 'all' — fuzzy by default to handle spelling variations and diacritics

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -126,7 +126,9 @@ class SpecialCollectionSearch
     'spatial_coverage' => 'metadata_spatialCoverage'
   }.freeze
 
-  EXACT_MATCH_FIELDS = %w[date language spatial_coverage rights].freeze
+  # Fields that should use term queries for exact matching
+  TERM_MATCH_FIELDS = %w[rights].freeze
+  EXACT_MATCH_FIELDS = %w[date language spatial_coverage].freeze
   ##
   # Converts the @criteria params hash (named field keys) into an array of
   # clause hashes suitable for AbstractRelation#query_clauses.
@@ -136,7 +138,13 @@ class SpecialCollectionSearch
     FIELD_MAP.filter_map do |key, field|
       query_text = @criteria[key].to_s.strip
       next if query_text.blank?
-      match_type = EXACT_MATCH_FIELDS.include?(key) ? 'exact' : 'all'
+      match_type = if TERM_MATCH_FIELDS.include?(key)
+                     'term'
+                   elsif EXACT_MATCH_FIELDS.include?(key)
+                     'exact'
+                   else
+                     'all'
+                   end
       { field: field, query: query_text, match: match_type, operator: 'AND' }
     end
   end

--- a/app/search/special_collection_search.rb
+++ b/app/search/special_collection_search.rb
@@ -126,7 +126,7 @@ class SpecialCollectionSearch
     'spatial_coverage' => 'metadata_spatialCoverage'
   }.freeze
 
-  EXACT_MATCH_FIELDS = %w[date language spatial_coverage].freeze
+  EXACT_MATCH_FIELDS = %w[date language spatial_coverage rights].freeze
   ##
   # Converts the @criteria params hash (named field keys) into an array of
   # clause hashes suitable for AbstractRelation#query_clauses.

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -93,69 +93,34 @@
 
   #advanced-search.tab-pane.fade{class: [('show active' if active_tab == 'advanced-search')], role: "tabpanel"}
     .row.justify-content-md-center.mt-4
-      .col-md-10 
+      .col-md-7
         = form_tag(search_landing_path, method: :get, id: 'advanced-search-form') do
           = hidden_field_tag(:tab, 'advanced-search')
           = hidden_field_tag(:q, '')
           - adv = @permitted_params[:criteria] || {}
-
+          - dynamic_fields = %w[keyword title creator contributor description format spatial_coverage identifier language publisher subject]
+          - default_fields = ['keyword', 'title', 'creator', 'language']
+          - adv_dynamic = adv.select { |k, _| dynamic_fields.include?(k) }.to_a
+          - used_keys = adv_dynamic.map(&:first)
+          - remaining = default_fields.reject { |f| used_keys.include?(f) }
+          - row_data = (adv_dynamic.first(4) + remaining.map { |f| [f, ''] }).first(4)
+          - field_options = [['Keyword (any field)', 'keyword'], ['Title', 'title'], ['Creator', 'creator'], ['Contributor', 'contributor'], ['Description', 'description'], ['Format', 'format'], ['Geographic Coverage', 'spatial_coverage'], ['Identifier', 'identifier'], ['Language', 'language'], ['Publisher', 'publisher'], ['Subject', 'subject']]
+          
           .mb-2
+            - row_data.each do |field_key, field_value|
+              .row.align-items-center.py-2.border-bottom
+                .col-sm-4 
+                  = select_tag "criteria_field_select", options_for_select(field_options, field_key), class: 'form-select', data: { criteria_field_select: true, default: field_key }
+                .col-sm-8
+                  = text_field_tag "criteria[#{field_key}]", field_value, class: 'form-control', data: {criteria_input: true }
             .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Keyword
-              .col-sm-9
-                = text_field_tag('criteria[keyword]', adv['keyword'], class: 'form-control', placeholder: 'Search across all fields')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Title
-              .col-sm-9
-                = text_field_tag('criteria[title]', adv['title'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Creator
-              .col-sm-9
-                = text_field_tag('criteria[creator]', adv['creator'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Contributor
-              .col-sm-9
-                = text_field_tag('criteria[contributor]', adv['contributor'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Subject
-              .col-sm-9
-                = text_field_tag('criteria[subject]', adv['subject'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Description
-              .col-sm-9
-                = text_field_tag('criteria[description]', adv['description'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Date
-              .col-sm-9
-                = text_field_tag('criteria[date]', adv['date'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Language
-              .col-sm-9
-                = text_field_tag('criteria[language]', adv['language'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Type
-              .col-sm-9
-                = text_field_tag('criteria[type]', adv['type'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Identifier
-              .col-sm-9
-                = text_field_tag('criteria[identifier]', adv['identifier'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Publisher
-              .col-sm-9
-                = text_field_tag('criteria[publisher]', adv['publisher'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Format
-              .col-sm-9
-                = text_field_tag('criteria[format]', adv['format'], class: 'form-control')
-            .row.align-items-center.py-2.border-bottom
-              %label.col-sm-3.col-form-label.fw-semibold Rights
-              .col-sm-9
-                = text_field_tag('criteria[rights]', adv['rights'], class: 'form-control')
+              %label.col-sm-4.col-form-label.fw-semibold Date
+              .col-sm-8
+                = text_field_tag "criteria[date]", adv['date'], class: 'form-control'
             .row.align-items-center.py-2
-              %label.col-sm-3.col-form-label.fw-semibold Geographic Coverage
-              .col-sm-9
-                = text_field_tag('criteria[spatial_coverage]', adv['spatial_coverage'], class: 'form-control')
+              %label.col-sm-4.col-form-label.fw-semibold Rights
+              .col-sm-8
+                = select_tag "criteria[rights]", options_from_collection_for_select(VocabularyTerm.rights_related, :string, :string, adv['rights']), include_blank: '-- Select --', class: 'form-select'
 
           .d-flex.justify-content-end.gap-2.mt-3
             %button.btn.btn-outline-secondary{type: 'button', id: 'advanced-search-clear'} Clear

--- a/app/views/search_landing/index.html.haml
+++ b/app/views/search_landing/index.html.haml
@@ -97,7 +97,7 @@
         = form_tag(search_landing_path, method: :get, id: 'advanced-search-form') do
           = hidden_field_tag(:tab, 'advanced-search')
           = hidden_field_tag(:q, '')
-          - adv = @permitted_params[:criteria] || {}
+          - adv = @permitted_params[:criteria]&.to_unsafe_h || {}
           - dynamic_fields = %w[keyword title creator contributor description format spatial_coverage identifier language publisher subject]
           - default_fields = ['keyword', 'title', 'creator', 'language']
           - adv_dynamic = adv.select { |k, _| dynamic_fields.include?(k) }.to_a

--- a/app/views/special_collections_search/index.html.haml
+++ b/app/views/special_collections_search/index.html.haml
@@ -38,6 +38,37 @@
 %h1.mt-5 Digital Collections  
 %h5 Digitized manuscripts, photographs, maps, and other special collections research materials, as well as personal and organizational digital archives.
 
+.row.justify-content-center.g-4.mt-4
+  -# Browse Repositories Tile
+  .col-12.col-sm-6.col-lg-3
+    = link_to repositories_path, class: "browse-tile-link" do
+      .browse-flip-card
+        .browse-flip-card-inner
+          .browse-flip-card-front
+            %h3 Browse Repositories
+          .browse-flip-card-back
+            %p Placeholder text - briefly describe Repositories and what users can expect to find.
+
+  -# Browse Collections Tile
+  .col-12.col-sm-6.col-lg-3
+    = link_to collections_path, class: "browse-tile-link" do
+      .browse-flip-card
+        .browse-flip-card-inner
+          .browse-flip-card-front
+            %h3 Browse Collections
+          .browse-flip-card-back
+            %p Placeholder text - briefly describe Collections and what users can expect to find.
+
+  -# Browse Items Tile
+  .col-12.col-sm-6.col-lg-3
+    = link_to items_path, class: "browse-tile-link" do
+      .browse-flip-card
+        .browse-flip-card-inner
+          .browse-flip-card-front
+            %h3 Browse Items
+          .browse-flip-card-back
+            %p Placeholder text - briefly describe Items and what users can expect to find.
+
 - if @permitted_params[:q].present?
   :javascript
     $(document).ready(function() {


### PR DESCRIPTION
Addresses the latest feedback/requirements in [issue 6](https://github.com/medusa-project/digital-library-issues/issues/6#issuecomment-5193245302):

1. Keep `public field options` as default, with dropdown options to use more advanced options for staff or power users
2. Include `Rights field dropdown separate` using the controlled vocabulary of rightsstatements.org options)
3. Condense the search page so it only shows the public default options, as opposed to a large window page with 14 different static fields

From user feedback:

> modeled off of how worldcat has their advanced search as well as familiar approaches with displaying field options in Primo and other library databases. Our stakeholders believed our users would find this field selection model a familiar approach for structuring an advanced search.

### Summary of Changes:
- Create a new `TERM_MATCH_FIELDS` constant for Rights field, that uses term queries for exact matching (based on controlled vocabulary) 
- Add a conditional that checks if query text key is included in `TERM_MATCH_FIELDS`. If it is, set the match type to term, otherwise use exact for `EXACT_MATCH_FIELDS`, or default to all if first two don't apply. 
  - this determines how the query is built on the backend 
  - bypasses the `custom analyzer "stop" words` used in the `opensearch index schema` (e.g. Without this logic, `"In Copyright"` Rights term has "in" which is a stop word. The custom analyzer reads that as "copyright" and returns all results with "copyright" in the term)
 - Add a change `Event Listener` that is wired to each field dropdown so the correct data criteria input is applied (e.g. Selecting Title in the dropdown ensures that the text input is matched against the Title metadata field)
 -  `Reset the dropdown select fields` to their default values and `re-sync the input names` when the form is cleared (resets the Rights dropdown to a default select/blank option) 
 - updated view:
<img width="1404" height="628" alt="Screenshot 2026-08-21 at 2 03 38 PM" src="https://github.com/user-attachments/assets/1bf8dc92-9f9f-4074-af25-4e13656dafe6" />

Browse Tiles added on new search landing page as advised [here](https://github.com/medusa-project/digital-library-issues/issues/176#issuecomment-5193319834). Screenshot below shows one of the tiles as it would appear when hovered over, with placeholder text in lieu of description:

<img width="1448" height="746" alt="Screenshot 2026-08-26 at 2 19 12 PM" src="https://github.com/user-attachments/assets/167fb9cf-4329-4445-8149-3afa8e066e34" />
